### PR TITLE
pass filename into traceur compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var Filter = require('broccoli-filter');
 var traceur = require('traceur');
+var _ = require('lodash');
 
 function TraceurFilter(inputTree, options) {
 	if (!(this instanceof TraceurFilter)) {
@@ -17,8 +18,9 @@ TraceurFilter.prototype.constructor = TraceurFilter;
 TraceurFilter.prototype.extensions = ['js'];
 TraceurFilter.prototype.targetExtension = 'js';
 
-TraceurFilter.prototype.processString = function (str) {
-	var result = traceur.compile(str, this.options);
+TraceurFilter.prototype.processString = function (str, relativePath) {
+	var options = _.merge({filename: relativePath}, this.options);
+	var result = traceur.compile(str, options);
 
 	if (result.errors && result.errors.length > 0) {
 		throw result.errors[0];

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   ],
   "dependencies": {
     "broccoli-filter": "^0.1.6",
-    "traceur": "~0.0.49"
+    "traceur": "~0.0.49",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "broccoli": "^0.12.0",


### PR DESCRIPTION
Currently the module compiler outputs `<unknown file>` as the module names if you pass `{moduleNames: true}` to the compiler. This PR passes in the filename to the compiler to output the correct module name.
