### PR TITLE
Correctly passing filename to Traceur.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 var Filter = require('broccoli-filter');
 var traceur = require('traceur');
-var objectAssign = require('object-assign');
 
 function TraceurFilter(inputTree, options) {
 	if (!(this instanceof TraceurFilter)) {
@@ -19,10 +18,8 @@ TraceurFilter.prototype.extensions = ['js'];
 TraceurFilter.prototype.targetExtension = 'js';
 
 TraceurFilter.prototype.processString = function (str, relativePath) {
-	var options = objectAssign({}, this.options, {filename: relativePath});
-
 	try {
-		return traceur.compile(str, options);
+		return traceur.compile(str, this.options, relativePath);
 	} catch (errs) {
 		throw errs.join('\n');
 	}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "broccoli-filter": "^0.1.6",
-    "object-assign": "^2.0.0",
     "traceur": "~0.0.84"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -19,5 +19,17 @@ it('complains if ES6 is invalid', function () {
 		assert(false, 'should fail');
 	}, function (err) {
 		assert(/Unexpected token/.test(err), err);
+		assert(/error\.js/.test(err), err);
+	});
+});
+
+it('includes file names', function () {
+	var builder = new broccoli.Builder(traceur('fixture/success', {
+		moduleName: true,
+		modules: "instantiate"
+	}));
+	return builder.build().then(function(dir) {
+		var content = fs.readFileSync(path.join(dir.directory, 'fixture.js'), 'utf8');
+		assert(/System\.register\(\"fixture\.js\"/.test(content), content);
 	});
 });


### PR DESCRIPTION
This pull request fixes a bug probably linked to a change in traceur: the way to pass the file name to traceur seems to have changed.
